### PR TITLE
fix: remove main branch from SonarCloud push triggers

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2,9 +2,10 @@ name: SonarCloud Analysis
 
 on:
   push:
-    branches: [main, develop]  # Only analyze default branches (free tier limitation)
+    branches: [develop]  # Only analyze develop branch (free tier limitation)
   pull_request:
     types: [opened, synchronize, reopened]
+    branches: [main, develop]  # Analyze PRs to main or develop
 
 jobs:
   sonarcloud:


### PR DESCRIPTION
SonarCloud free tier only analyzes PRs, not main branch pushes.
Updated workflow to only analyze develop pushes and PRs to main/develop.

This prevents SonarCloud failures when merging to main.